### PR TITLE
Validate and force short hostname if one has fqdn in the inventory file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
    when: ansible_os_family == "RedHat"
 
  - name: populate genders file
-   template: src='pdsh_genders.j2' dest='/etc/genders' mode='0644' owner=root group=root
+   template: src='pdsh_genders.j2' dest='/etc/genders' mode='0644' owner=root group=root validate='nodeattr --parse-check -f %s'
 
  - name: Remove old /etc/machines to avoid confusion
    file: path=/etc/machines state=absent

--- a/templates/pdsh_genders.j2
+++ b/templates/pdsh_genders.j2
@@ -1,4 +1,4 @@
 {% for groupname in groups %}
 {% for hname in groups[groupname] %}
-{{ hostvars[hname].inventory_hostname }},{% endfor %} {{ groupname }}
+{{ hostvars[hname].inventory_hostname.split('.')[0] }},{% endfor %} {{ groupname }}
 {% endfor %}


### PR DESCRIPTION
1) Validate

Adding this will make the whole play fail if there is an error.

2) This makes the population work if one has full hostnames like below in the inventory file.

There will be errors if the nodes are not using a "shortened name" - if in the inventory one has like this:

<pre>
[grid]
io-grid.fgci.csc.fi int_ip_addr=10.1.1.3 ext_ip_addr=86.50.166.64
</pre> 


command output:

<pre>
$ nodeattr --parse-check -f /etc/genders ; echo $?
Line 1: node not a shortened hostname
Line 3: node not a shortened hostname
Line 7: node not a shortened hostname
Line 8: node not a shortened hostname
Line 9: node not a shortened hostname
Line 10: node not a shortened hostname
Line 11: node not a shortened hostname
nodeattr: 7 parse errors discovered
7
</pre>


ansible output:

<pre>
TASK [ansible-role-pdsh-genders : populate genders file] ***********************
fatal: [io-install.fgci.csc.fi]: FAILED! => {"changed": true, "exit_status": 7, "failed": true, "msg": "failed to validate", "stderr": "Line 1: node not a shortened hostname\nLine 3: node not a shortened hostname\nLine 7: node not a shortened hostname\nLine 8: node not a shortened hostname\nLine 9: node not a shortened hostname\nLine 10: node not a shortened hostname\nLine 11: node not a shortened hostname\nnodeattr: 7 parse errors discovered\n", "stdout": "", "stdout_lines": []}
</pre>
