### PR TITLE
new syntax in meta/main.yml for dependency

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -144,5 +144,5 @@ dependencies:
   # List your role dependencies here, one per line.
   # Be sure to remove the '[]' above if you add dependencies
   # to this list.
-  - { role: ansible-role-fgci-repo }
+  - { src: ansible-role-fgci-repo }
   


### PR DESCRIPTION
"role" should be "src"

to get rid of this warning when running ansible-galaxy:
<pre>
- extracting ansible-role-pdsh-genders to /home/admin/ansible/io/fgci-ansible/roles/ansible-role-pdsh-genders
- ansible-role-pdsh-genders was installed successfully
[DEPRECATION WARNING]: The comma separated role spec format, use the yaml/explicit format 
instead..
This feature will be removed in a future release. Deprecation warnings can be 
disabled by setting deprecation_warnings=False in ansible.cfg.
</pre>

Confirmed that the role still runs the required role before.