### PR TITLE
also set a name in the dependency definition

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -144,5 +144,5 @@ dependencies:
   # List your role dependencies here, one per line.
   # Be sure to remove the '[]' above if you add dependencies
   # to this list.
-  - { src: ansible-role-fgci-repo }
+  - { src: ansible-role-fgci-repo, name: ansible-role-fgci-repo }
   


### PR DESCRIPTION
Think we also need to do set a name:

ansible-role-slurm didn't play nice without it

https://travis-ci.org/CSC-IT-Center-for-Science/ansible-role-slurm/builds/178266084#L4004