### PR TITLE
fix warnings

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -7,11 +7,9 @@
    with_items: "{{ pdsh_genders_conflict }}"
 
  - name: install pdsh and dependencies EL7
-   yum: name={{ item }} state=installed
-   with_items: "{{ pdsh_el7_packages }}"
+   yum: name={{ pdsh_el7_packages }} state=installed
    when: ansible_distribution_major_version == "7"
 
  - name: install pdsh and dependencies EL6
-   yum: name={{ item }} state=installed
-   with_items: "{{ pdsh_el6_packages }}"
+   yum: name={{ pdsh_el6_packages }} state=installed
    when: ansible_distribution_major_version == "6"


### PR DESCRIPTION
fix warnings:
[DEPRECATION WARNING]: Invoking "yum" only once while using a loop via squash_actions is deprecated. Instead of 
using a loop to supply multiple items and specifying `name: {{ item }}`, please use `name: u'{{ pdsh_el7_packages 
}}'` and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by 
setting deprecation_warnings=False in ansible.cfg.